### PR TITLE
Fixed a cover issue with `--one-shot`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.py]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ A few arguments can be passed to mpdnotify:
 
 * **-a / --appname** : specifies the app name for notify-send.
 * **-c / --config** : path to the configuration file.
-* **--host** : mpd's address.
+* **-h / --host** : mpd's address.
 * **-m / --musicdir** : path to mpd's music library folder.
 * **-p / --port** : mpd's server port.
 * **-o / --oneshot** : send a notification and exit immediately.
+* **-t / --timeout** : amount of milliseconds for which notification will be shown
 
 All of these arguments can be save in a configuration file, please see [`mpdnotifyrc.sample`](https://github.com/chuugar/mpdnotify/blob/master/mpdnotifyrc.sample) for further informations.
 

--- a/README.md
+++ b/README.md
@@ -35,18 +35,18 @@ pip3 install -r requirements.txt -e .
 
 A few arguments can be passed to mpdnotify:
 
-* **-a / --appname** : specifies the app name for notify-send.
-* **-c / --config** : path to the configuration file.
-* **-h / --host** : mpd's address.
-* **-m / --musicdir** : path to mpd's music library folder.
-* **-p / --port** : mpd's server port.
-* **-o / --oneshot** : send a notification and exit immediately.
-* **-t / --timeout** : amount of milliseconds for which notification will be shown
+* `-a` / `--appname`: specifies the app name for notify-send.
+* `-c` / `--config`: path to the configuration file.
+* `--host`: mpd's address.
+* `-m` / `--musicdir`: path to mpd's music library folder.
+* `-p` / `--port`: mpd's server port.
+* `-o` / `--oneshot`: send a notification and exit immediately.
+* `-t` / `--timeout`: amount of milliseconds for which notification will be shown.
 
 All of these arguments can be save in a configuration file, please see [`mpdnotifyrc.sample`](https://github.com/chuugar/mpdnotify/blob/master/mpdnotifyrc.sample) for further informations.
 
-**Once running, `mpdnotify` will wait for the next song to send a notification** (unless **-o / --oneshot** has been passed).
-Cover is used as notification icon if a file (cover/front/album).(png/jpg) is find in the same folder as the music file.
+**Once running, `mpdnotify` will wait for the next song to send a notification** (unless `-o` / `--oneshot` has been passed).
+Cover is used as notification icon if a file called `(cover/front/album).(png/jpg)` is find in the same folder as the music file.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Notifies when mpd's song changes.
 
 ## Installation
 
-It has been test on Debian 9.5, it shall work on any other Linux distribution with Python >= 3.2.
+It has been tested on Debian 9.5, it shall work on any other Linux distribution with Python >= 3.2.
 Please let me now if it works on OSX.
 
 ### PyPa
 
-You can install `mpdnotify` in a single command :
+You can install `mpdnotify` in a single command:
 `pip install mpdnotify`
 
 ### Manual
@@ -33,7 +33,8 @@ pip3 install -r requirements.txt -e .
 
 ## Usage
 
-A few arguments can be passed to mpdnotify :
+A few arguments can be passed to mpdnotify:
+
 * **-a / --appname** : specifies the app name for notify-send.
 * **-c / --config** : path to the configuration file.
 * **--host** : mpd's address.
@@ -41,7 +42,7 @@ A few arguments can be passed to mpdnotify :
 * **-p / --port** : mpd's server port.
 * **-o / --oneshot** : send a notification and exit immediately.
 
-All this arguments can be save in a configuration file, please see `mpdnotifyrc.sample` for further informations.
+All of these arguments can be save in a configuration file, please see [`mpdnotifyrc.sample`](https://github.com/chuugar/mpdnotify/blob/master/mpdnotifyrc.sample) for further informations.
 
 **Once running, `mpdnotify` will wait for the next song to send a notification** (unless **-o / --oneshot** has been passed).
 Cover is used as notification icon if a file (cover/front/album).(png/jpg) is find in the same folder as the music file.
@@ -49,5 +50,5 @@ Cover is used as notification icon if a file (cover/front/album).(png/jpg) is fi
 ## TODO
 
 * Add a test suite.
-* Allow user to change the notification format.
+* Allow the user to change the notification format.
 * If cover cannot be found as an image, look at the tags.

--- a/README.md
+++ b/README.md
@@ -35,21 +35,38 @@ pip3 install -r requirements.txt -e .
 
 A few arguments can be passed to mpdnotify:
 
-* `-a` / `--appname`: specifies the app name for notify-send.
-* `-c` / `--config`: path to the configuration file.
-* `--host`: mpd's address.
-* `-m` / `--musicdir`: path to mpd's music library folder.
-* `-p` / `--port`: mpd's server port.
-* `-o` / `--oneshot`: send a notification and exit immediately.
-* `-t` / `--timeout`: amount of milliseconds for which notification will be shown.
+* **`-a` / `--appname`**: specifies the app name for notify-send.
+* **`-c` / `--config`**: path to the configuration file.
+* **`-f` / `--titleformat`**: format for the notification title ([see here](#formatting)).
+* **`-b` / `--bodyformat`**: format for the notification body ([see here](#formatting)).
+* **`--host`**: mpd's address.
+* **`-m` / `--musicdir`**: path to mpd's music library folder.
+* **`-p` / `--port`**: mpd's server port.
+* **`-o` / `--oneshot`**: send a notification and exit immediately.
+* **`-t` / `--timeout`**: amount of milliseconds for which notification will be shown.
 
 All of these arguments can be save in a configuration file, please see [`mpdnotifyrc.sample`](https://github.com/chuugar/mpdnotify/blob/master/mpdnotifyrc.sample) for further informations.
 
-**Once running, `mpdnotify` will wait for the next song to send a notification** (unless `-o` / `--oneshot` has been passed).
+**Once running, `mpdnotify` will wait for the next song to send a notification** (unless **`-o` / `--oneshot`** has been passed).
 Cover is used as notification icon if a file called `(cover/front/album).(png/jpg)` is find in the same folder as the music file.
+
+## Formatting
+
+You can use these values in title and body formats:
+
+* `{title}`
+* `{album}`
+* `{artist}`
+
+If you want to use literal curly brackets, double them like this:
+
+    {{NOW PLAYING}} {title} - {album} ({arist})
+
+That would look like this while playing, for example, the song [IRC by Master Boot Record](https://masterbootrecord.bandcamp.com/track/irc):
+
+    {NOW PLAYING} IRC - INTERNET PROTOCOL (MASTER BOOT RECORD)
 
 ## TODO
 
 * Add a test suite.
-* Allow the user to change the notification format.
 * If cover cannot be found as an image, look at the tags.

--- a/mpdnotify/cli.py
+++ b/mpdnotify/cli.py
@@ -3,7 +3,7 @@ from mpdnotify import config, notify
 
 def main():
   pref = config.GlobalParser()
-  mpd = notify.MPD(pref.host, pref.port, pref.musicdir, pref.appname, pref.timeout)
+  mpd = notify.MPD(pref.host, pref.port, pref.musicdir, pref.appname, pref.timeout, pref.titleformat, pref.bodyformat)
 
   if pref.oneshot:
     mpd.sendnotify()

--- a/mpdnotify/cli.py
+++ b/mpdnotify/cli.py
@@ -3,7 +3,7 @@ from mpdnotify import config, notify
 
 def main():
   pref = config.GlobalParser()
-  mpd = notify.MPD(pref.host, pref.port, pref.musicdir)
+  mpd = notify.MPD(pref.host, pref.port, pref.musicdir, pref.appname, pref.timeout)
 
   if pref.oneshot:
     mpd.sendnotify()

--- a/mpdnotify/cli.py
+++ b/mpdnotify/cli.py
@@ -2,21 +2,21 @@ from mpdnotify import config, notify
 
 
 def main():
-    pref = config.GlobalParser()
-    mpd = notify.MPD(pref.host, pref.port, pref.musicdir)
+  pref = config.GlobalParser()
+  mpd = notify.MPD(pref.host, pref.port, pref.musicdir)
 
-    if pref.oneshot:
+  if pref.oneshot:
+    mpd.sendnotify()
+  else:
+    try:
+      while True:
+        mpd.clean_covers()
+        mpd.watch()
         mpd.sendnotify()
-    else:
-        try:
-            while True:
-                mpd.clean_covers()
-                mpd.watch()
-                mpd.sendnotify()
-        except KeyboardInterrupt:
-            print("\nBye !")
-        finally:
-            mpd.clean_covers(force=True)
+    except KeyboardInterrupt:
+      print("\nBye!")
+    finally:
+      mpd.clean_covers(force=True)
 
 
 if __name__ == "__main__":

--- a/mpdnotify/config.py
+++ b/mpdnotify/config.py
@@ -15,7 +15,8 @@ __preferences__ = {
   "host": "localhost",
   "port": "6600",
   "appname": "mpd",
-  "musicdir": "",
+  "timeout": "2500",
+  "musicdir": ""
 }
 
 
@@ -79,14 +80,15 @@ class GlobalParser(object):
 
   def _parsing_arguments(self):
     parser = argparse.ArgumentParser()
+
     parser.add_argument("-a", "--appname", metavar="mpd")
     parser.add_argument("-c", "--config", metavar="mpdnotifyrc")
     parser.add_argument("--host", metavar="localhost", type=str)
-    parser.add_argument(
-      "-m", "--musicdir", metavar="/path/to/your/mpd/dir"
-    )
+    parser.add_argument("-m", "--musicdir", metavar="/path/to/your/mpd/dir")
     parser.add_argument("-p", "--port", metavar="6600", type=int)
     parser.add_argument("-o", "--oneshot", action="store_true")
+    parser.add_argument("-t", "--timeout", metavar="2500", type=int)
+
     return parser.parse_args()
 
   def _parsing_config(self):
@@ -112,9 +114,7 @@ class GlobalParser(object):
       # finally try to looks at the config directory
     else:
       try:
-        config_home = pathlib.Path(
-          environ.get("XDG_CONFIG_HOME")
-        ).expanduser()
+        config_home = pathlib.Path(environ.get("XDG_CONFIG_HOME")).expanduser()
       except KeyError:
         config_home = pathlib.Path("~/.config").expanduser()
       finally:

--- a/mpdnotify/config.py
+++ b/mpdnotify/config.py
@@ -11,49 +11,51 @@ Priority : command-line argument > config > environment > hardcoded
 """
 
 __preferences__ = {
-  "config": "mpdnotifyrc",
-  "host": "localhost",
-  "port": "6600",
   "appname": "mpd",
-  "timeout": "2500",
-  "musicdir": ""
+  "config": "mpdnotifyrc",
+  "titleformat": "{title}",
+  "bodyformat": "{album} ({artist})",
+  "host": "localhost",
+  "musicdir": "",
+  "port": "6600",
+  "timeout": "3500"
 }
 
 
 class GlobalParser(object):
   def __init__(self):
-    for _ in __preferences__:
-      setattr(self, _, "")
+    for pref in __preferences__:
+      setattr(self, pref, "")
 
     # self.empty_pref will help us to save the unset preferences
     self.empty_pref = []
     # first check if the preferences are set from within the CLI
     args = self._parsing_arguments()
-    for _ in __preferences__:
-      if getattr(args, _):
-        setattr(self, _, getattr(args, _))
+    for pref in __preferences__:
+      if getattr(args, pref):
+        setattr(self, pref, getattr(args, pref))
       else:
-        self.empty_pref.append(_)
+        self.empty_pref.append(pref)
 
     # then looks at the config file, if any, to fill the missing arguments
     # as they are read from self.empty_pref
     config = self._parsing_config()
     if config:
-      for _ in self.empty_pref[:]:
+      for pref in self.empty_pref[:]:
         try:
-          setattr(self, _, config.get("mpdnotify", _))
+          setattr(self, pref, config.get("mpdnotify", pref))
         except configparser.NoOptionError:
-          self.empty_pref.append(_)
+          self.empty_pref.append(pref)
         else:
-          self.empty_pref.remove(_)
+          self.empty_pref.remove(pref)
 
     # last try with default options (corresponding to __preferences__ items)
-    for _ in self.empty_pref[:]:
-      if __preferences__.get(_) != "":
-        setattr(self, _, __preferences__.get(_))
-        self.empty_pref.remove(_)
+    for pref in self.empty_pref[:]:
+      if __preferences__.get(pref) != "":
+        setattr(self, pref, __preferences__.get(pref))
+        self.empty_pref.remove(pref)
       else:
-        self.empty_pref.append(_)
+        self.empty_pref.append(pref)
 
     # special case since always defined from within the CLI
     self.oneshot = args.oneshot
@@ -72,7 +74,7 @@ class GlobalParser(object):
     if self.empty_pref:
       for i in self.empty_pref:
         print("{} must be specified".format(i))
-      self._exit("All requierement are not satisfied", 2)
+      self._exit("All requirement are not satisfied", 2)
 
   def _exit(self, msg, error):
     print(msg)
@@ -81,13 +83,17 @@ class GlobalParser(object):
   def _parsing_arguments(self):
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("-a", "--appname", metavar="mpd")
-    parser.add_argument("-c", "--config", metavar="mpdnotifyrc")
-    parser.add_argument("--host", metavar="localhost", type=str)
-    parser.add_argument("-m", "--musicdir", metavar="/path/to/your/mpd/dir")
-    parser.add_argument("-p", "--port", metavar="6600", type=int)
+    parser.add_argument("-a", "--appname",     metavar=__preferences__["appname"])
+    parser.add_argument("-c", "--config",      metavar=__preferences__["config"])
+
+    parser.add_argument("-f", "--titleformat", metavar=__preferences__["titleformat"])
+    parser.add_argument("-b", "--bodyformat",  metavar=__preferences__["bodyformat"])
+
+    parser.add_argument("--host", type=str,    metavar=__preferences__["host"])
+    parser.add_argument("-m", "--musicdir",    metavar=__preferences__["musicdir"])
+    parser.add_argument("-p", "--port",        metavar=__preferences__["port"], type=int)
     parser.add_argument("-o", "--oneshot", action="store_true")
-    parser.add_argument("-t", "--timeout", metavar="2500", type=int)
+    parser.add_argument("-t", "--timeout",     metavar=__preferences__["timeout"], type=int)
 
     return parser.parse_args()
 
@@ -115,7 +121,8 @@ class GlobalParser(object):
     else:
       try:
         config_home = pathlib.Path(environ.get("XDG_CONFIG_HOME")).expanduser()
-      except KeyError:
+      # If XDG_CONFIG_HOME doesn't exist, pathlib.Path will throw a TypeError
+      except (KeyError, TypeError):
         config_home = pathlib.Path("~/.config").expanduser()
       finally:
         config_list = (
@@ -124,9 +131,10 @@ class GlobalParser(object):
             .joinpath("mpdnotify")
             .joinpath("mpdnotifyrc"),
         )
-        for _ in config_list:
-          if _.exists():
-            self.config = _
+
+        for config in config_list:
+          if config.exists():
+            self.config = config
 
     if self.config:
       config = configparser.ConfigParser()

--- a/mpdnotify/config.py
+++ b/mpdnotify/config.py
@@ -83,7 +83,7 @@ class GlobalParser(object):
 
     parser.add_argument("-a", "--appname", metavar="mpd")
     parser.add_argument("-c", "--config", metavar="mpdnotifyrc")
-    parser.add_argument("--host", metavar="localhost", type=str)
+    parser.add_argument("-h", "--host", metavar="localhost", type=str)
     parser.add_argument("-m", "--musicdir", metavar="/path/to/your/mpd/dir")
     parser.add_argument("-p", "--port", metavar="6600", type=int)
     parser.add_argument("-o", "--oneshot", action="store_true")

--- a/mpdnotify/config.py
+++ b/mpdnotify/config.py
@@ -83,7 +83,7 @@ class GlobalParser(object):
 
     parser.add_argument("-a", "--appname", metavar="mpd")
     parser.add_argument("-c", "--config", metavar="mpdnotifyrc")
-    parser.add_argument("-h", "--host", metavar="localhost", type=str)
+    parser.add_argument("--host", metavar="localhost", type=str)
     parser.add_argument("-m", "--musicdir", metavar="/path/to/your/mpd/dir")
     parser.add_argument("-p", "--port", metavar="6600", type=int)
     parser.add_argument("-o", "--oneshot", action="store_true")

--- a/mpdnotify/config.py
+++ b/mpdnotify/config.py
@@ -1,8 +1,9 @@
+from os import environ
+from sys import exit
+
 import argparse
 import configparser
 import pathlib
-from os import environ
-from sys import exit
 
 
 """Get user preferences
@@ -10,131 +11,132 @@ Priority : command-line argument > config > environment > hardcoded
 """
 
 __preferences__ = {
-    "config": "mpdnotifyrc",
-    "host": "localhost",
-    "port": "6600",
-    "appname": "mpd",
-    "musicdir": "",
+  "config": "mpdnotifyrc",
+  "host": "localhost",
+  "port": "6600",
+  "appname": "mpd",
+  "musicdir": "",
 }
 
 
 class GlobalParser(object):
-    def __init__(self):
-        for _ in __preferences__:
-            setattr(self, _, "")
+  def __init__(self):
+    for _ in __preferences__:
+      setattr(self, _, "")
 
-        # self.empty_pref will help us to save the unset preferences
-        self.empty_pref = []
-        # first check if the preferences are set from within the CLI
-        args = self._parsing_arguments()
-        for _ in __preferences__:
-            if getattr(args, _):
-                setattr(self, _, getattr(args, _))
-            else:
-                self.empty_pref.append(_)
+    # self.empty_pref will help us to save the unset preferences
+    self.empty_pref = []
+    # first check if the preferences are set from within the CLI
+    args = self._parsing_arguments()
+    for _ in __preferences__:
+      if getattr(args, _):
+        setattr(self, _, getattr(args, _))
+      else:
+        self.empty_pref.append(_)
 
-        # then looks at the config file, if any, to fill the missing arguments
-        # as they are read from self.empty_pref
-        config = self._parsing_config()
-        if config:
-            for _ in self.empty_pref[:]:
-                try:
-                    setattr(self, _, config.get("mpdnotify", _))
-                except configparser.NoOptionError:
-                    self.empty_pref.append(_)
-                else:
-                    self.empty_pref.remove(_)
-
-        # last try with default options (corresponding to __preferences__'
-        # items)
-        for _ in self.empty_pref[:]:
-            if __preferences__.get(_) != "":
-                setattr(self, _, __preferences__.get(_))
-                self.empty_pref.remove(_)
-            else:
-                self.empty_pref.append(_)
-
-        # special case since always defined from within the CLI
-        self.oneshot = args.oneshot
-
-        # try to guess mpd's music folder
-        if not self.musicdir:
-            try:
-                environ["XDG_MUSIC_DIR"]
-            except KeyError:
-                pass
-            else:
-                self.musicdir = environ.get("XDG_MUSIC_DIR")
-                self.empty_pref.remove("musicdir")
-
-        # if some preference cannot be filled : exit
-        if self.empty_pref:
-            for i in self.empty_pref:
-                print("{} must be specified".format(i))
-            self._exit("All requierement are not satisfied", 2)
-
-    def _exit(self, msg, error):
-        print(msg)
-        exit(error)
-
-    def _parsing_arguments(self):
-        parser = argparse.ArgumentParser()
-        parser.add_argument("-a", "--appname", metavar="mpd")
-        parser.add_argument("-c", "--config", metavar="mpdnotifyrc")
-        parser.add_argument("--host", metavar="localhost", type=str)
-        parser.add_argument(
-            "-m", "--musicdir", metavar="/path/to/your/mpd/dir"
-        )
-        parser.add_argument("-p", "--port", metavar="6600", type=int)
-        parser.add_argument("-o", "--oneshot", action="store_true")
-        return parser.parse_args()
-
-    def _parsing_config(self):
-        """
-        :type returns: dict
-        """
-
-        def _is_file(_file):
-            if isinstance(_file, pathlib.PosixPath):
-                return _file.is_file()
-            if pathlib.Path(_file).is_file():
-                return True
-
-        cwd_config = pathlib.Path.cwd().joinpath("mpdnotifyrc")
-        # first looks at args
-        if not _is_file(cwd_config) and self.config != "":
-            if not isinstance(self.config, pathlib.Path):
-                self.config = pathlib.Path(self.config)
-        # else try to find the config file in the current dir
-        elif _is_file(cwd_config) and self.config == "":
-            self.config = cwd_config
-            # finally try to looks at the config directory
+    # then looks at the config file, if any, to fill the missing arguments
+    # as they are read from self.empty_pref
+    config = self._parsing_config()
+    if config:
+      for _ in self.empty_pref[:]:
+        try:
+          setattr(self, _, config.get("mpdnotify", _))
+        except configparser.NoOptionError:
+          self.empty_pref.append(_)
         else:
-            try:
-                config_home = pathlib.Path(
-                    environ.get("XDG_CONFIG_HOME")
-                ).expanduser()
-            except KeyError:
-                config_home = pathlib.Path("~/.config").expanduser()
-            finally:
-                config_list = (
-                    pathlib.Path(config_home).joinpath("mpdnotifyrc"),
-                    pathlib.Path(config_home)
-                    .joinpath("mpdnotify")
-                    .joinpath("mpdnotifyrc"),
-                )
-                for _ in config_list:
-                    if _.exists():
-                        self.config = _
+          self.empty_pref.remove(_)
 
-        if self.config:
-            config = configparser.ConfigParser()
-            try:
-                config.read(self.config.__str__())
-            except configparser.ParsingError:
-                self._exit("Error while parsing the configuration file", 3)
-            else:
-                if "mpdnotify" in config.sections():
-                    return config
-                else:
-                    self._exit("No [mpdnotify] within the config file", 3)
+    # last try with default options (corresponding to __preferences__ items)
+    for _ in self.empty_pref[:]:
+      if __preferences__.get(_) != "":
+        setattr(self, _, __preferences__.get(_))
+        self.empty_pref.remove(_)
+      else:
+        self.empty_pref.append(_)
+
+    # special case since always defined from within the CLI
+    self.oneshot = args.oneshot
+
+    # try to guess mpd's music folder
+    if not self.musicdir:
+      try:
+        environ["XDG_MUSIC_DIR"]
+      except KeyError:
+        pass
+      else:
+        self.musicdir = environ.get("XDG_MUSIC_DIR")
+        self.empty_pref.remove("musicdir")
+
+    # if some preference cannot be filled : exit
+    if self.empty_pref:
+      for i in self.empty_pref:
+        print("{} must be specified".format(i))
+      self._exit("All requierement are not satisfied", 2)
+
+  def _exit(self, msg, error):
+    print(msg)
+    exit(error)
+
+  def _parsing_arguments(self):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-a", "--appname", metavar="mpd")
+    parser.add_argument("-c", "--config", metavar="mpdnotifyrc")
+    parser.add_argument("--host", metavar="localhost", type=str)
+    parser.add_argument(
+      "-m", "--musicdir", metavar="/path/to/your/mpd/dir"
+    )
+    parser.add_argument("-p", "--port", metavar="6600", type=int)
+    parser.add_argument("-o", "--oneshot", action="store_true")
+    return parser.parse_args()
+
+  def _parsing_config(self):
+    """
+    :type returns: dict
+    """
+
+    def _is_file(_file):
+      if isinstance(_file, pathlib.PosixPath):
+        return _file.is_file()
+      if pathlib.Path(_file).is_file():
+        return True
+
+    cwd_config = pathlib.Path.cwd().joinpath("mpdnotifyrc")
+
+    # first looks at args
+    if not _is_file(cwd_config) and self.config != "":
+      if not isinstance(self.config, pathlib.Path):
+        self.config = pathlib.Path(self.config)
+    # else try to find the config file in the current dir
+    elif _is_file(cwd_config) and self.config == "":
+      self.config = cwd_config
+      # finally try to looks at the config directory
+    else:
+      try:
+        config_home = pathlib.Path(
+          environ.get("XDG_CONFIG_HOME")
+        ).expanduser()
+      except KeyError:
+        config_home = pathlib.Path("~/.config").expanduser()
+      finally:
+        config_list = (
+          pathlib.Path(config_home).joinpath("mpdnotifyrc"),
+          pathlib.Path(config_home)
+            .joinpath("mpdnotify")
+            .joinpath("mpdnotifyrc"),
+        )
+        for _ in config_list:
+          if _.exists():
+            self.config = _
+
+    if self.config:
+      config = configparser.ConfigParser()
+
+      try:
+        config.read(self.config.__str__())
+      except configparser.ParsingError:
+        self._exit("Error while parsing the configuration file", 3)
+      else:
+        if "mpdnotify" in config.sections():
+          return config
+        else:
+          self._exit("No [mpdnotify] within the config file", 3)

--- a/mpdnotify/mpd.py
+++ b/mpdnotify/mpd.py
@@ -2,72 +2,73 @@ import socket
 
 
 class MPDClient(object):
-    def __init__(self, host="localhost", port=6600):
-        self.host = host
-        self.port = port
-        self.timeout = None
-        self._sock = None
+  def __init__(self, host="localhost", port=6600):
+    self.host = host
+    self.port = port
+    self.timeout = None
+    self._sock = None
 
-    def _connect_tcp(self, host, port):
-        if not host:
-            host = self.host
-        if not port:
-            port = self.port
+  def _connect_tcp(self, host, port):
+    if not host:
+      host = self.host
+    if not port:
+      port = self.port
 
-        try:
-            flags = socket.AI_ADDRCONFIG
-        except AttributeError:
-            flags = 0
+    try:
+      flags = socket.AI_ADDRCONFIG
+    except AttributeError:
+      flags = 0
 
-        for res in socket.getaddrinfo(
-            self.host,
-            self.port,
-            socket.AF_UNSPEC,
-            socket.SOCK_STREAM,
-            socket.IPPROTO_TCP,
-            flags,
-        ):
-            af, socktype, proto, canonname, sa = res
+    for res in socket.getaddrinfo(
+      self.host,
+      self.port,
+      socket.AF_UNSPEC,
+      socket.SOCK_STREAM,
+      socket.IPPROTO_TCP,
+      flags,
+    ):
+      af, socktype, proto, canonname, sa = res
 
-            sock = None
-            try:
-                sock = socket.socket(af, socktype, proto)
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-                sock.settimeout(self.timeout)
-                sock.connect(sa)
-                return sock
-            except socket.error:
-                sock.close()
-
-    def _connect_unix(self, path):
-        if not hasattr(socket, "AF_UNIX"):
-            raise ConnectionError(
-                "Unix domain sockets not supported on this platform"
-            )
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.connect(path)
+      sock = None
+      try:
+        sock = socket.socket(af, socktype, proto)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        sock.settimeout(self.timeout)
+        sock.connect(sa)
         return sock
+      except socket.error:
+        sock.close()
 
-    def _hello(self):
-        self._rfile.readline()
+  def _connect_unix(self, path):
+    if not hasattr(socket, "AF_UNIX"):
+      raise ConnectionError("Unix domain sockets not supported on this platform")
 
-    def connect(self, host=None, port=None):
-        if not host:
-            host = self.host
-        if not port:
-            port = self.port
-        if self._sock is not None:
-            raise ConnectionError("Already connected")
-        if host.startswith("/"):
-            self._sock = self._connect_unix(host)
-        else:
-            self._sock = self._connect_tcp(host, port)
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(path)
+    return sock
 
-        self._rfile = self._sock.makefile("r", encoding="utf-8", newline="\n")
-        self._wfile = self._sock.makefile("w", encoding="utf-8", newline="\n")
-        self._hello()
+  def _hello(self):
+    self._rfile.readline()
 
-    def idle(self):
-        self._wfile.write("idle\tplayer\n")
-        self._wfile.flush()
-        self._rfile.readline()
+  def connect(self, host=None, port=None):
+    if not host:
+      host = self.host
+    if not port:
+      port = self.port
+
+    if self._sock is not None:
+      raise ConnectionError("Already connected")
+
+    if host.startswith("/"):
+      self._sock = self._connect_unix(host)
+    else:
+      self._sock = self._connect_tcp(host, port)
+
+    self._rfile = self._sock.makefile("r", encoding="utf-8", newline="\n")
+    self._wfile = self._sock.makefile("w", encoding="utf-8", newline="\n")
+    self._hello()
+
+  def idle(self):
+    self._wfile.write("idle\tplayer\n")
+    self._wfile.flush()
+    self._rfile.readline()

--- a/mpdnotify/notify.py
+++ b/mpdnotify/notify.py
@@ -35,6 +35,8 @@ class MPD:
                 self.cover_list.append(name.capitalize() + ext)
                 self.cover_list.append(name.capitalize() + ext.upper())
 
+        self.cover = self.get_cover()
+
     def clean_covers(self, limit=20, force=False):
         """ Clean useless covers' files
         since resized covers' images are saved within a named temporary file

--- a/mpdnotify/notify.py
+++ b/mpdnotify/notify.py
@@ -1,137 +1,137 @@
-import pathlib
-from PIL import Image
-
 from tempfile import NamedTemporaryFile
 from subprocess import run
 from mpd import MPDClient
+from PIL import Image
+
+import pathlib
 
 
 class MPD:
-    def __init__(self, host, port, music_dir, appname="mpd"):
-        self.host = host
-        self.port = port
-        self.appname = appname
-        self.music_dir = music_dir
+  def __init__(self, host, port, music_dir, appname="mpd"):
+    self.host = host
+    self.port = port
+    self.appname = appname
+    self.music_dir = music_dir
 
-        self.mpd = MPDClient()
-        self.mpd.connect(self.host, self.port)
+    self.mpd = MPDClient()
+    self.mpd.connect(self.host, self.port)
 
-        self.title = self.get_title()
-        self.artist = self.get_artist()
-        self.album = self.get_album()
-        self.file = self.get_file()
+    self.title = self.get_title()
+    self.artist = self.get_artist()
+    self.album = self.get_album()
+    self.file = self.get_file()
 
-        self.body, self.notify_run = "", ""
-        self.garbagecover = []
+    self.body, self.notify_run = "", ""
+    self.garbagecover = []
 
-        #  generates a list of cover name as they are usually found
-        self.cover_list = []
-        for name in ("album", "front", "cover"):
-            for ext in (".jpg", ".png"):
-                self.cover_list.append(name + ext)
-                self.cover_list.append(name + ext.upper())
-                self.cover_list.append(name.upper() + ext)
-                self.cover_list.append(name.upper() + ext.upper())
-                self.cover_list.append(name.capitalize() + ext)
-                self.cover_list.append(name.capitalize() + ext.upper())
+    #  generates a list of cover name as they are usually found
+    self.cover_list = []
+    for name in ("album", "front", "cover"):
+      for ext in (".jpg", ".png"):
+        self.cover_list.append(name + ext)
+        self.cover_list.append(name + ext.upper())
+        self.cover_list.append(name.upper() + ext)
+        self.cover_list.append(name.upper() + ext.upper())
+        self.cover_list.append(name.capitalize() + ext)
+        self.cover_list.append(name.capitalize() + ext.upper())
 
-        self.cover = self.get_cover()
+    self.cover = self.get_cover()
 
-    def clean_covers(self, limit=20, force=False):
-        """ Clean useless covers' files
-        since resized covers' images are saved within a named temporary file
-        it's necessary to delete it when they are not in use anymore
-        NB : if the cover image is delete too fast the notification pop-up
-        might lose its icon
-        """
-        if force:
-            for _ in self.garbagecover:
-                _.unlink()
-        else:
-            mid = limit // 2
-            if len(self.garbagecover) > limit:
-                for _ in self.garbagecover[0:mid]:
-                    _.unlink()
-                    self.garbagecover.remove(_)
+  def clean_covers(self, limit=20, force=False):
+    """ Clean useless covers' files
+    since resized covers' images are saved within a named temporary file
+    it's necessary to delete it when they are not in use anymore
+    NB : if the cover image is delete too fast the notification pop-up
+    might lose its icon
+    """
+    if force:
+      for _ in self.garbagecover:
+        _.unlink()
+    else:
+      mid = limit // 2
+      if len(self.garbagecover) > limit:
+        for _ in self.garbagecover[0:mid]:
+          _.unlink()
+          self.garbagecover.remove(_)
 
-    def get_artist(self):
-        return self.mpd.currentsong().get("artist")
+  def get_artist(self):
+    return self.mpd.currentsong().get("artist")
 
-    def get_album(self):
-        return self.mpd.currentsong().get("album")
+  def get_album(self):
+    return self.mpd.currentsong().get("album")
 
-    def get_cover(self):
-        try:
-            # without .expanduser(), pathlib doesn't work right with '~'
-            # cf. https://bugs.python.org/issue19776
-            music_dir = pathlib.Path(self.music_dir).expanduser()
-            parent = music_dir.joinpath(self.file).parent
-        except TypeError:
-            return ""
-        else:
-            for _ in parent.iterdir():
-                if _.name in self.cover_list:
-                    return parent.joinpath(_.name)
+  def get_cover(self):
+    try:
+      # without .expanduser(), pathlib doesn't work right with '~'
+      # cf. https://bugs.python.org/issue19776
+      music_dir = pathlib.Path(self.music_dir).expanduser()
+      parent = music_dir.joinpath(self.file).parent
+    except TypeError:
+      return ""
+    else:
+      for _ in parent.iterdir():
+        if _.name in self.cover_list:
+          return parent.joinpath(_.name)
 
-    def get_file(self):
-        return self.mpd.currentsong().get("file")
+  def get_file(self):
+    return self.mpd.currentsong().get("file")
 
-    def get_title(self):
-        return self.mpd.currentsong().get("title")
+  def get_title(self):
+    return self.mpd.currentsong().get("title")
 
-    def sendnotify(self, cover=False):
-        self.body = "{} ({})".format(self.artist, self.album)
-        if self.cover:
-            self.notify_run = [
-                "notify-send",
-                "-a",
-                self.appname,
-                "-i",
-                self.cover.__str__(),
-                self.title,
-                self.body,
-            ]
-        else:
-            self.notify_run = [
-                "notify-send",
-                "-a",
-                self.appname,
-                self.title,
-                self.body,
-            ]
-        try:
-            run(self.notify_run)
-        except TypeError:
-            pass
+  def sendnotify(self, cover=False):
+    self.body = "{} ({})".format(self.artist, self.album)
 
-    def resize_cover(self):
-        im = Image.open(self.cover)
-        im = im.resize((96, 96))
+    if self.cover:
+      self.notify_run = [
+        "notify-send",
+        "-a",
+        self.appname,
+        "-i",
+        self.cover.__str__(),
+        self.title,
+        self.body,
+      ]
+    else:
+      self.notify_run = [
+        "notify-send",
+        "-a",
+        self.appname,
+        self.title,
+        self.body,
+      ]
 
-        with NamedTemporaryFile(
-            suffix=".png", prefix="mpdnotify-", delete=False
-        ) as resize_cover:
-            p = pathlib.Path(resize_cover.name)
-            im.save(p, "png")
+    try:
+      run(self.notify_run)
+    except TypeError:
+      pass
 
-        self.garbagecover.append(p)
-        self.cover = p
+  def resize_cover(self):
+    im = Image.open(self.cover)
+    im = im.resize((96, 96))
 
-    def watch(self):
-        old_title = self.title
-        while True:
-            self.clean_covers()
-            self.mpd.idle()
+    with NamedTemporaryFile(suffix=".png", prefix="mpdnotify-", delete=False) as resize_cover:
+      p = pathlib.Path(resize_cover.name)
+      im.save(p, "png")
 
-            self.title = self.get_title()
-            self.album = self.get_album()
-            self.artist = self.get_artist()
-            self.file = self.get_file()
+    self.garbagecover.append(p)
+    self.cover = p
 
-            self.cover = self.get_cover()
-            if self.cover:
-                self.resize_cover()
+  def watch(self):
+    old_title = self.title
+    while True:
+      self.clean_covers()
+      self.mpd.idle()
 
-            # prevent multiple undesired notification
-            if old_title != self.title:
-                break
+      self.title = self.get_title()
+      self.album = self.get_album()
+      self.artist = self.get_artist()
+      self.file = self.get_file()
+
+      self.cover = self.get_cover()
+      if self.cover:
+        self.resize_cover()
+
+      # prevent multiple undesired notifications
+      if old_title != self.title:
+        break

--- a/mpdnotify/notify.py
+++ b/mpdnotify/notify.py
@@ -7,11 +7,12 @@ import pathlib
 
 
 class MPD:
-  def __init__(self, host, port, music_dir, appname="mpd"):
+  def __init__(self, host, port, music_dir, appname, timeout):
     self.host = host
     self.port = port
-    self.appname = appname
     self.music_dir = music_dir
+    self.appname = appname
+    self.timeout = timeout
 
     self.mpd = MPDClient()
     self.mpd.connect(self.host, self.port)
@@ -89,6 +90,8 @@ class MPD:
         self.appname,
         "-i",
         self.cover.__str__(),
+        "-t",
+        self.timeout.__str__(),
         self.title,
         self.body,
       ]
@@ -97,6 +100,8 @@ class MPD:
         "notify-send",
         "-a",
         self.appname,
+        "-t",
+        self.timeout.__str__(),
         self.title,
         self.body,
       ]

--- a/mpdnotifyrc.sample
+++ b/mpdnotifyrc.sample
@@ -10,6 +10,9 @@
 host = localhost
 port = 6600
 
+titleformat = {title}
+bodyformat = {album} ({artist})
+
 # Amount of milliseconds for which notification will be shown
 timeout = 2500
 

--- a/mpdnotifyrc.sample
+++ b/mpdnotifyrc.sample
@@ -1,14 +1,17 @@
 # This is mpdnotifyrc.sample
 # Please copy this file at one those locations:
 #       ~/.config/mpdnotifyrc
-#       ~/.config/mpdnotify/mpdnotifyrc 
-# It also can be read from within the current working directory
+#       ~/.config/mpdnotify/mpdnotifyrc
+# It also can be read from the current working directory
 # You can also use `mpdnotify -c /path/to/your/mpdnotifyrc`
 
 [mpdnotify]
 # Points to your mpd server address and port
 host = localhost
 port = 6600
+
+# Amount of milliseconds for which notification will be shown
+timeout = 2500
 
 # What name will be parsed by libnotify (see notify-send --help)
 appname = mpd

--- a/setup.py
+++ b/setup.py
@@ -2,33 +2,33 @@ from setuptools import setup, find_packages
 from mpdnotify import __productname__, __version__
 
 with open("README.md", "r") as fh:
-    long_description = fh.read()
+  long_description = fh.read()
 
 setup(
-        name=__productname__,
-        version=__version__,
-        description='mpdnotify - get notification when changing song',
-        long_description=long_description,
-        long_description_content_type="text/markdown",
-        url='https://github.com/chuugar/mpdnotify',
-        author='chuugar',
-        author_email='charles-thomas@sfr.fr',
-        license='GPL3',
-        packages=find_packages(),
-        entry_points={
-            'console_scripts': ['mpdnotify=mpdnotify.cli:main'],
-            },
-        include_package_data=True,
-        install_requires=[
-            'python-mpd2',
-            'Pillow',
-            ],
-        classifiers=[
-            'Environment :: Console',
-            'Environment :: Console :: Curses',
-            'License :: OSI Approved :: GNU General Public License (GPL)',
-            'Programming Language :: Python :: 3',
-            'Topic :: Multimedia :: Sound/Audio :: Mixers',
-            'Topic :: Utilities',
-            ],
-        )
+  name=__productname__,
+  version=__version__,
+  description='mpdnotify - get notification when changing song',
+  long_description=long_description,
+  long_description_content_type="text/markdown",
+  url='https://github.com/chuugar/mpdnotify',
+  author='chuugar',
+  author_email='charles-thomas@sfr.fr',
+  license='GPL3',
+  packages=find_packages(),
+  entry_points={
+    'console_scripts': ['mpdnotify=mpdnotify.cli:main'],
+  },
+  include_package_data=True,
+  install_requires=[
+    'python-mpd2',
+    'Pillow',
+  ],
+  classifiers=[
+    'Environment :: Console',
+    'Environment :: Console :: Curses',
+    'License :: OSI Approved :: GNU General Public License (GPL)',
+    'Programming Language :: Python :: 3',
+    'Topic :: Multimedia :: Sound/Audio :: Mixers',
+    'Topic :: Utilities',
+  ],
+)


### PR DESCRIPTION
On my system, `mpdnotify -o` threw an exception, because the `MPD.cover` attribute in `notify.py` wasn't set in the constructor.

This PR solves that issue and corrects a couple of minor typos in the README.